### PR TITLE
Fix usage of "|" for tests

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -17,7 +17,7 @@
     name: zookeeper
     comment: "Apache zookeeper Service"
   register: create_zookeeper_user
-  until: create_zookeeper_user | success
+  until: create_zookeeper_user is success
   retries: 5
   delay: 2
 
@@ -28,7 +28,7 @@
     mode: 0600
     validate_certs: no
   register: download_zookeeper
-  until: download_zookeeper | success
+  until: download_zookeeper is success
   retries: 5
   delay: 3
 
@@ -40,7 +40,7 @@
     copy: no
     owner: zookeeper
   register: extract_zookeeper
-  until: extract_zookeeper | success
+  until: extract_zookeeper is success
   retries: 5
   delay: 3
 


### PR DESCRIPTION
With the more recent versions of ansible, we should now use
"is" instead of the "|" sign for the tests.

This should fix it.